### PR TITLE
Use isodate to parse version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file.
 Please follow [the Keep a Changelog standard](https://keepachangelog.com/en/1.0.0/).
 
-## [0.1.2] - 2024-01-15
+## [0.2.0] - 2024-01-15
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 Please follow [the Keep a Changelog standard](https://keepachangelog.com/en/1.0.0/).
 
+## [0.1.2] - 2024-01-15
+
+### Changed
+
+* Version header now parsed using `fromisoformat` for performance improvment
+
 ## [0.1.1] - 2024-01-15
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "verselect"
-version = "0.1.2"
+version = "0.2.0"
 description = ""
 authors = ["Bogdan Evstratenko <evstrat.bg@gmail.com>", "Stanislav Zmiev <zmievsa@gmail.com>"]
 repository = "https://github.com/team-monite/verselect"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "verselect"
-version = "0.1.1"
+version = "0.1.2"
 description = ""
 authors = ["Bogdan Evstratenko <evstrat.bg@gmail.com>", "Stanislav Zmiev <zmievsa@gmail.com>"]
 repository = "https://github.com/team-monite/verselect"

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -19,7 +19,7 @@ from verselect.app import HeaderRoutingFastAPI
 def test__header_routing__invalid_version_format__error():
     main_app = HeaderRoutingFastAPI()
     main_app.add_header_versioned_routers(header_value=DEFAULT_API_VERSION)
-    with pytest.raises(ValueError, match=re.escape("header_value should be in `%Y-%m-%d` format")):
+    with pytest.raises(ValueError, match=re.escape("header_value should be in ISO 8601 format")):
         main_app.add_header_versioned_routers(APIRouter(), header_value="2022-01_01")
 
 

--- a/verselect/app.py
+++ b/verselect/app.py
@@ -1,5 +1,5 @@
 from contextvars import ContextVar
-from datetime import date, datetime
+from datetime import date
 from logging import getLogger
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Sequence
@@ -12,8 +12,6 @@ from fastapi.responses import JSONResponse
 from fastapi.routing import APIRouter
 from fastapi.templating import Jinja2Templates
 from starlette.routing import BaseRoute, Route
-
-from verselect.routing import VERSION_HEADER_FORMAT
 
 from .middleware import HeaderVersioningMiddleware, _get_api_version_dependency
 from .routing import RootHeaderAPIRouter
@@ -106,7 +104,7 @@ class HeaderRoutingFastAPI(FastAPI):
             self.swaggers["unversioned"] = unversioned_routes_openapi
 
         for header_value, routes in self.router.versioned_routes.items():
-            header_value_str = header_value.strftime(VERSION_HEADER_FORMAT)
+            header_value_str = header_value.isoformat()
             openapi = get_openapi(
                 title=self.title,
                 version=self.version,
@@ -157,9 +155,9 @@ class HeaderRoutingFastAPI(FastAPI):
     ) -> list[BaseRoute]:
         """Add all routes from routers to be routed using header_value and return the added routes"""
         try:
-            header_value_as_dt = datetime.strptime(header_value, VERSION_HEADER_FORMAT).date()
+            header_value_as_dt = date.fromisoformat(header_value)
         except ValueError as e:
-            raise ValueError(f"header_value should be in `{VERSION_HEADER_FORMAT}` format") from e
+            raise ValueError("header_value should be in ISO 8601 format") from e
 
         added_routes: list[BaseRoute] = []
         for router in routers:


### PR DESCRIPTION
I did some profiling using yappi. Header parsing is the second cpu consuming thing after json serialization

```
Sorted by tsub - How much time this function has spent in total, subcalls excluded.
name                                  ncall  tsub      ttot      tavg                                                                                                               
..i/encoders.py:101 jsonable_encoder  445/5  0.004316  0.010260  0.000023                                                                                                           
..hon3.11/_strptime.py:309 _strptime  100    0.002192  0.005411  0.000054                                                                                                           
..1/asyncio/tasks.py:35 current_task  418    0.001467  0.002333  0.000006
```

`fromisoformat` load cpu much less